### PR TITLE
chore: update to node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Delete Draft Releases'
 description: 'Delete draft releases in your repository'
 author: 'Hugo Ferrando Seage'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
node 12 is being deprecated in actions...

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/