### PR TITLE
Use node16 instead of node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Delete Draft Releases'
 description: 'Delete draft releases in your repository'
 author: 'Hugo Ferrando Seage'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'tag'


### PR DESCRIPTION
Upgrade to node16 from node12, because of the depreciation of node12 in the github runner.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/